### PR TITLE
s/Hearths/Hearts/ correcting a typo in wallpaper name.

### DIFF
--- a/DrywallPatternColours/ModAssets/translations/de.po
+++ b/DrywallPatternColours/ModAssets/translations/de.po
@@ -91,7 +91,7 @@ msgctxt ""
 "DrywallPatternColours.STRINGS.BUILDINGS."
 "PREFABS_MODDEDSKINS.EXTERIORWALL.FACADES."
 "PINK_FLAMINGO.NAME"
-msgid "<link=\"EXTERIORWALL\">Hearths</link>"
+msgid "<link=\"EXTERIORWALL\">Hearts</link>"
 msgstr "<link=\"EXTERIORWALL\">Herzchen</link>"
 
 #. DrywallPatternColours.STRINGS.BUILDINGS.PREFABS_MODDEDSKINS.EXTERIORWALL.FACADES.RED_DEEP.DESC

--- a/DrywallPatternColours/STRINGS.cs
+++ b/DrywallPatternColours/STRINGS.cs
@@ -49,7 +49,7 @@ namespace DrywallPatternColours
 
                         public class PINK_FLAMINGO
                         {
-                            public static LocString NAME = (LocString)UI.FormatAsLink("Hearths", nameof(EXTERIORWALL));
+                            public static LocString NAME = (LocString)UI.FormatAsLink("Hearts", nameof(EXTERIORWALL));
                             public static LocString DESC = (LocString)"A pink wallpaper.";
                         }
 


### PR DESCRIPTION
I suggest you also change the description to `"A beloved wallpaper."`, but YMMV on that one.