### PR TITLE
CGM: Add trait tag to override world rules

### DIFF
--- a/ClusterTraitGenerationManager/ClusterData/StarmapItem.cs
+++ b/ClusterTraitGenerationManager/ClusterData/StarmapItem.cs
@@ -588,6 +588,9 @@ namespace ClusterTraitGenerationManager.ClusterData
             {
                 return new List<WorldTrait>();
             }
+
+            List<WorldTrait> AlwaysAvailableTraits = AllTraits.FindAll((WorldTrait trait) => trait.traitTags.Contains(ModAssets.OverrideWorldRules_AlwaysAllow));
+
             List<string> ExclusiveWithTags
                 = new List<string>();
 
@@ -620,6 +623,7 @@ namespace ClusterTraitGenerationManager.ClusterData
                     || !trait.IsValid(world, logErrors: true));
 
             }
+            AllTraits = AllTraits.Union(AlwaysAvailableTraits).ToList();
             AllTraits.RemoveAll((WorldTrait trait) =>
                  !trait.IsValid(world, logErrors: true)
                 || trait.exclusiveWithTags.Any(x => ExclusiveWithTags.Any(y => y == x))

--- a/ClusterTraitGenerationManager/ModAssets.cs
+++ b/ClusterTraitGenerationManager/ModAssets.cs
@@ -296,6 +296,8 @@ namespace ClusterTraitGenerationManager
         public static readonly string CustomTraitID = "traits/CGMRandomTraits";
         public static WorldTrait RandomizedTraitsTrait;
 
+        public static readonly string OverrideWorldRules_AlwaysAllow = "CGM_OverrideWorldRules_AlwaysAllow";
+
         public static Dictionary<ProcGen.World, List<string>> ChangedMeteorSeasons = new Dictionary<ProcGen.World, List<string>>();
 
         public static Dictionary<string, WorldTrait> AllTraitsWithRandomDict


### PR DESCRIPTION
Add special handling for the `CGM_OverrideWorldRules_AlwaysAllow` trait tag so that CGM allows the trait to be selected even if it's disallowed by world rules. Exclusive traits are still honoured.

The main purpose of this trait tag is to have traits that cannot appear by default on planets, but that can be manually added through CGM. This can be accomplished with the following trait tags:

  - CGM_OverrideWorldRules_AlwaysAllow
  - StartWorldOnly
  - NonStartWorld