### PR TITLE
Directory.Build.props: Make folder properties overridable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+	<Import Condition=" !Exists('Directory.Build.props.user') " Project="Directory.Build.props.default" />
+	<Import Condition=" Exists('Directory.Build.props.user') " Project="Directory.Build.props.user" />
+
 	<PropertyGroup>
-		<!--Gamedata Folder, adjust to your own ONI installation-->
-		<GameLibsFolder>X:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed</GameLibsFolder>
-		<!--OutputModFolder, adjust it to your own dev folder-->
-		<ModFolder>E:\Documents\Klei\OxygenNotIncluded\mods\dev</ModFolder>
-		<!--Default for dev folder: -->
-		<!--<ModFolder>$(UserProfile)\Documents\Klei\OxygenNotIncluded\mods\dev</ModFolder>-->
 		<Optimize>true</Optimize>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>

--- a/Directory.Build.props.default
+++ b/Directory.Build.props.default
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Instead of modifying this file, create a copy named Directory.Build.props.user and modify it to match the paths in your installation -->
+<Project>
+	<PropertyGroup>
+		<!--Gamedata Folder, adjust to your own ONI installation-->
+		<GameLibsFolder>X:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed</GameLibsFolder>
+		<!--OutputModFolder, adjust it to your own dev folder-->
+		<ModFolder>E:\Documents\Klei\OxygenNotIncluded\mods\dev</ModFolder>
+		<!--Default for dev folder: -->
+		<!--<ModFolder>$(UserProfile)\Documents\Klei\OxygenNotIncluded\mods\dev</ModFolder>-->
+	</PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mods for Oxygen Not Included and ONI - Spaced Out.
 
 ## How to build this Repository
 1. clone/download repository and open it in visual studio
-2. adjust the variables "ModFolder" and "GameLibsFolder" inside of Directory.Build.Props to reference your local dev folder and your game folder. This will relink all references to the game assemblies.
+2. make a copy of the `Directory.Build.props.default` file and name it `Directory.Build.props.user`, then adjust the variables "ModFolder" and "GameLibsFolder" inside of the copy to reference your local dev folder and your game folder. This will relink all references to the game assemblies.
 3. run "clean" on the 1_CycleComma project. This runs the publicise task to create publicised versions of the game assembly (all variables and functions are made public). If it does not work, try restoring NuGet packages on that mod.
 4. Done. All mods should now be able to compile properly and be copied to the dev-folder on completion. If you want to make a new mod and use this repository as a base, make sure to allow "Unsafe Code" in the new mods project settings as this is required for using publiciser (Update; this should now happen automatically via solution setting). A project template file is included with "UpdatedOniTemplate.zip".
 


### PR DESCRIPTION
The `GameLibsFolder` and `ModFolder` properties need to be adjusted to match one's environment. But modifying `Directory.Build.props` results in the Git worktree being dirty, which prevents switching branches. To avoid this, place the default values for these properties inside a new `Directory.Build.props.default` file. The defaults are imported unless a `Directory.Build.props.user` file exists, in which case the per-user file gets imported instead. The per-user file is ignored by Git, which avoids dirtying the worktree. Moreover, update the README accordingly.