### PR TITLE
RE: Allow docking door to work as floor

### DIFF
--- a/Rockets-TinyYetBig/Docking/DockingTubeDoorConfig.cs
+++ b/Rockets-TinyYetBig/Docking/DockingTubeDoorConfig.cs
@@ -62,7 +62,7 @@ namespace Rockets_TinyYetBig.Buildings
             buildingDef.SceneLayer = Grid.SceneLayer.BuildingFront;
             buildingDef.ObjectLayer = ObjectLayer.AttachableBuilding;
             buildingDef.PermittedRotations = PermittedRotations.Unrotatable;
-
+            buildingDef.ContinuouslyCheckFoundation = false;
 
             //buildingDef.OnePerWorld = true;
 
@@ -93,7 +93,7 @@ namespace Rockets_TinyYetBig.Buildings
             FakeFloorAdder fakeFloorAdder = go.AddOrGet<FakeFloorAdder>();
             fakeFloorAdder.floorOffsets =  new CellOffset[]
             {
-                new CellOffset(1, -1)
+                new CellOffset(0, -1)
             };
             fakeFloorAdder.initiallyActive = true;
         }


### PR DESCRIPTION
This is useful for tiny rockets where the actual floor tile is missing.