### PR TITLE
Rocketry Expanded: Fix crash about element state

### DIFF
--- a/Rockets-TinyYetBig/ModAssets.cs
+++ b/Rockets-TinyYetBig/ModAssets.cs
@@ -274,9 +274,10 @@ namespace Rockets_TinyYetBig
 				{
 					var ele = ElementLoader.GetElement(fueltank.FuelType);
 
-					if(ele != null)
+					if(ele != null && !ele.IsVacuum)
 					{
-						FuelTanksPool[ele.state].Add(fueltank);
+						//Mask out non-state related bits
+						FuelTanksPool[ele.state & Element.State.Solid].Add(fueltank);
 					}
 					else if (clusterModule.TryGetComponent<ConduitConsumer>(out var conduitConsumer))
 					{


### PR DESCRIPTION
Looks like Klei uses the lower 2 bits for actual element state (Vacuum, Gas, Liquid, Solid), and higher bits represent special properties, such as Unbreakable, Unstable and TemperatureInsulated.

The `ReplacedCargoLoadingMethod` function reads element state to decide which fuel tank to use for an element. However, it did not mask out the non-state bits, and would crash (key not in dictionary) if elements had any non-state flag bits set.

Mask out non-state bits and check if the element state is vacuum before accessing the dictionary. This stops the game from crashing if elements have an unusual state.