### PR TITLE
Rocketry Expanded: Fix crash about element state (again)

### DIFF
--- a/Rockets-TinyYetBig/ModAssets.cs
+++ b/Rockets-TinyYetBig/ModAssets.cs
@@ -357,7 +357,8 @@ namespace Rockets_TinyYetBig
 							GameObject storageItem = AllItems[index];
 							if (!storageItem.TryGetComponent<PrimaryElement>(out var primaryElement))
 								continue;
-							var elementState = primaryElement.Element.state;
+							//Mask out non-state related bits
+							var elementState = primaryElement.Element.state & Element.State.Solid;
 
 
 							foreach (FuelTank fueltank in FuelTanksPool[elementState])


### PR DESCRIPTION
Commit 5ac1bb52498 (Rocketry Expanded: Fix crash about element state) fixed a crash when the element state has extra flags for some reason, but didn't catch all cases where this can be a problem. So, apply the same fix in another place of the same function to avoid these crashes when trying to use fuel loaders.