### PR TITLE
Configure dotnet sdk

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "jetbrains.refasmer.clitool": {
+      "version": "2.0.2",
+      "commands": [
+        "refasmer"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,7 @@
 # default for csharp files.
 # Note: This is only used by command line
 ###############################################################################
-#*.cs     diff=csharp
+*.cs     text diff=csharp
 
 ###############################################################################
 # Set the merge driver for project and solution files

--- a/ClusterTraitGenerationManager/ClusterMapGenerationManager.csproj
+++ b/ClusterTraitGenerationManager/ClusterMapGenerationManager.csproj
@@ -41,7 +41,7 @@
 	
 	<ItemGroup>
 	  <Reference Include="UnityEngine.InputLegacyModule">
-	    <HintPath>X:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+	    <HintPath>$(GameLibsFolder)\UnityEngine.InputLegacyModule.dll</HintPath>
 	  </Reference>
 	</ItemGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 	<!--Write mod.yaml file-->
-	<Target Name="GenerateModYaml" BeforeTargets="Build" Condition="'$(DoNotBuildAsMod)' != 'true'">
+	<Target Name="GenerateModYaml" BeforeTargets="PrepareForRun" Condition="'$(DoNotBuildAsMod)' != 'true'">
 		<ItemGroup>
 			<ModLines Include="title: '$(ModName)'"/>
 			<ModLines Include="description: '$(ModDescription)'"/>
@@ -10,9 +10,12 @@
 			<!--<ModLines Include="steamID: $(SteamId)" Condition="'$(SteamId)' != ''"/>--> <!--Causes recoverable parse errors :/-->
 		</ItemGroup>
 		<WriteLinesToFile File="$(TargetDir)/mod.yaml" Overwrite="true" Lines="@(ModLines)"/>
+    <ItemGroup>
+      <FileWrites Include="$(TargetDir)/mod.yaml" Condition="Exists('$(TargetDir)/mod.yaml')"/>
+    </ItemGroup>
 	</Target>
 	<!--Write mod_info.yaml file-->
-	<Target Name="GenerateModInfoYaml" BeforeTargets="Build" Condition="'$(DoNotBuildAsMod)' != 'true'">
+	<Target Name="GenerateModInfoYaml" BeforeTargets="PrepareForRun" Condition="'$(DoNotBuildAsMod)' != 'true'">
 		<ItemGroup>
 			<ModInfoLines Include="minimumSupportedBuild: $(TargetGameVersion)"/>
 			<ModInfoLines Include="version: $(Version)"/>
@@ -23,9 +26,12 @@
 			<ModInfoLines Include="$([System.String]::Copy('$(ForbiddenDlcIds)').Insert(0,' - ').Replace(',','%0a- '))" Condition="'$(ForbiddenDlcIds)' != ''"/>
 		</ItemGroup>
 		<WriteLinesToFile File="$(TargetDir)/mod_info.yaml" Overwrite="true" Lines="@(ModInfoLines)"/>
+    <ItemGroup>
+      <FileWrites Include="$(TargetDir)/mod_info.yaml" Condition="Exists('$(TargetDir)/mod_info.yaml')"/>
+    </ItemGroup>
 	</Target>
 	<!--Write LauncherMetadata.json file for Romen ModLauncher and SgtsModUpdater-->
-	<Target Name="GenerateLauncherMetadata" BeforeTargets="Build" Condition="'$(DoNotBuildAsMod)' != 'true'">
+	<Target Name="GenerateLauncherMetadata" BeforeTargets="PrepareForRun" Condition="'$(DoNotBuildAsMod)' != 'true'">
 		<ItemGroup>
 			<LauncherMetadataLines Include='{'/>
 			<LauncherMetadataLines Include='"UpdateIndexName":"Mods by Sgt_Imalas",'/>
@@ -36,6 +42,9 @@
 			<LauncherMetadataLines Include='}'/>
 		</ItemGroup>
 		<WriteLinesToFile File="$(TargetDir)/LauncherMetadata.json" Overwrite="true" Lines="@(LauncherMetadataLines)"/>
+    <ItemGroup>
+      <FileWrites Include="$(TargetDir)/LauncherMetadata.json" Condition="Exists('$(TargetDir)/LauncherMetadata.json')"/>
+    </ItemGroup>
 	</Target>
 
 	<!--Merges all dlls in the output folder into a single dll-->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -48,12 +48,10 @@
 		</ItemGroup>
 
 		<ILRepack
-		  TargetPlatformVersion="v4"
 		  TargetKind="SameAsPrimaryAssembly"
 		  InputAssemblies="@(InputAssemblies)"
 		  Wildcards="true"
 		  LibraryPath="$(GameLibsFolder)"
-		  Parallel="true"
 		  OutputFile="$(TargetPath)"/>
 	</Target>
 

--- a/_SgtsModUpdater/_SgtsModUpdater.csproj
+++ b/_SgtsModUpdater/_SgtsModUpdater.csproj
@@ -22,7 +22,7 @@
 		<Reference Remove="Assembly-CSharp" />
 		<Reference Remove="Assembly-CSharp-firstpass" />
 		<Reference Include="UnityEngine.SharedInternalsModule">
-			<HintPath>X:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\UnityEngine.SharedInternalsModule.dll</HintPath>
+			<HintPath>$(GameLibsFolder)\UnityEngine.SharedInternalsModule.dll</HintPath>
 		</Reference>
 	</ItemGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
# Change summary

We categorize the changes into two categories: _new features_ and _maintenance_. The new features are discussed in this PR. Maintenance changes include fixes and cleanup, which are less interesting to share.

1. New features
    - [x] 82dae0cb Configures the 'dotnet' SDK and tools.
    - [x] c5ffe73 Cleans generates files incrementally.
2. Maintenance
    - [x] 28f25818 Fixes the ILRepack for builds with 'dotnet' SDK on CLI.
    - [x] 2409deae Fixes hardcoded paths to GameLibs.

## 1. dotnet configuration 82dae0cb

The configuration of `dotnet` SDK tools is primarily managed through manifest files to specify and standardize package and toolchain versions across builds. We introduce the two main manifest files.

| Manifest  | Purpose |
| :------------- | :------------- |
| `global.json` | Specifies the minimum version for the `dotnet` SDK.  |
| `.config\tools.json`  | Specifies the packages and versions for .NET tools (e.g. `refasmer`).   |

The manifest files allow new contributors to provision their development environment as follows:

```pwsh
# 1. Provision `refasmer`, `Publiciser`, and other nuget packages.
PS> dotnet tool restore
PS> dotnet restore
# 2. Then build the solution.
# PS> dotnet build -c:Release
```

> [!NOTE]
> Both major C# IDEs, Visual Studio and JetBrains Rider, automatically install an appropriate SDK version when the manifest files exist (`global.json`). For a manual installation of the `dotnet` SDK, see official sources (e.g. from [dotnet.microsoft.com](https://dotnet.microsoft.com/en-us/download/dotnet)).
 
### dotnet global.json

We include the standard manifest files to use the default maintenance policies. For example:

- `rollForward = "latestMajor"` to use features in newer versions of `dotnet` SDK.
- `allowPrerelease = "false"` to avoid build failures from beta tests.

> [!NOTE]
> The general maintenance strategy is to specify an LTS version (.NET 6, .NET 8, .NET 10, ...) in `global.json` for the minimum SDK version. Then accept newer SDK versions locally with the policy `rollForward = "latestMajor"`. 

### dotnet tools

To provision tools for new contributors/machines, we add `refasmer` to the tool manifest `.config\tools.json` managed by `dotnet`:

```pwsh
# Restore all tools including `refasmer` as a local package installation.
PS> dotnet tool restore
```

To browse, install, and update tools (i.e. easy maintenance):

```pwsh
# Search for tools (on nuget or other)
PS> dotnet tool search refasmer
# Install a tool (updates '.config\tools.json')
PS> dotnet tool install jetbrains.refasmer.clitool
# Update all tools.
PS> dotnet tool update --all
```

## 2. Incremental build c5ffe739

To reduce build time (increase development velocity), we have more changes towards _incremental build_ (caches output artifacts to avoid redundant rebuilds).

To begin, we prepare generated files:

- `mod.yaml`
- `mod_info.yaml`
- `LauncherMetadata.json`

The generated files now participate in _incremental clean_ (pruning stale artifacts between builds). Expect the output directory `bin` to be clean after executing target `Clean`.

> [!NOTE]
> See the details of the protocol for 'IncrementalClean' in c5ffe739 if you are interested. 