### PR TITLE
Add Simplified Chinese translation for Natural Construction

### DIFF
--- a/NaturalConstruction/ModAssets/translations/zh.po
+++ b/NaturalConstruction/ModAssets/translations/zh.po
@@ -1,0 +1,109 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-07-31 00:00-0700\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"Application: Oxygen Not IncludedPOT Version: 2.0\n"
+
+#. NaturalConstruction.STRINGS.BUILDINGS.PREFABS.NC_NATURALBACKWALL.DESC
+msgctxt "NaturalConstruction.STRINGS.BUILDINGS.PREFABS.NC_NATURALBACKWALL.DESC"
+msgid "Very natural, much wow."
+msgstr "非常自然，真不错。"
+
+#. NaturalConstruction.STRINGS.BUILDINGS.PREFABS.NC_NATURALBACKWALL.EFFECT
+msgctxt "NaturalConstruction.STRINGS.BUILDINGS.PREFABS.NC_NATURALBACKWALL.EFFECT"
+msgid ""
+"Creates a natural backwall on finishing construction.\n"
+"Mass can be configured during construction."
+msgstr ""
+"建造完成后生成一面自然背景墙。\n"
+"建造时可以调整质量。"
+
+#. NaturalConstruction.STRINGS.BUILDINGS.PREFABS.NC_NATURALBACKWALL.NAME
+msgctxt "NaturalConstruction.STRINGS.BUILDINGS.PREFABS.NC_NATURALBACKWALL.NAME"
+msgid "<link=\"NCNATURALBACKWALL\">Natural Backwall</link>"
+msgstr "<link=\"NCNATURALBACKWALL\">自然背景墙</link>"
+
+#. NaturalConstruction.STRINGS.BUILDINGS.PREFABS.NC_NATURALTILE.DESC
+msgctxt "NaturalConstruction.STRINGS.BUILDINGS.PREFABS.NC_NATURALTILE.DESC"
+msgid "Very natural, much wow."
+msgstr "非常自然，真不错。"
+
+#. NaturalConstruction.STRINGS.BUILDINGS.PREFABS.NC_NATURALTILE.EFFECT
+msgctxt "NaturalConstruction.STRINGS.BUILDINGS.PREFABS.NC_NATURALTILE.EFFECT"
+msgid ""
+"Creates a natural tile on finishing construction.\n"
+"Mass can be configured during construction."
+msgstr ""
+"建造完成后生成一块自然砖。\n"
+"建造时可以调整质量。"
+
+#. NaturalConstruction.STRINGS.BUILDINGS.PREFABS.NC_NATURALTILE.NAME
+msgctxt "NaturalConstruction.STRINGS.BUILDINGS.PREFABS.NC_NATURALTILE.NAME"
+msgid "<link=\"NCNATURALTILE\">Natural Tile</link>"
+msgstr "<link=\"NCNATURALTILE\">自然砖</link>"
+
+#. NaturalConstruction.STRINGS.UI.NC_MODCONFIG.CONSTRUCTION_MASS_MULTIPLIER.TITLE
+msgctxt "NaturalConstruction.STRINGS.UI.NC_MODCONFIG.CONSTRUCTION_MASS_MULTIPLIER.TITLE"
+msgid "Spawn Mass multiplier"
+msgstr "生成质量倍率"
+
+#. NaturalConstruction.STRINGS.UI.NC_MODCONFIG.CONSTRUCTION_MASS_MULTIPLIER.TOOLTIP
+msgctxt "NaturalConstruction.STRINGS.UI.NC_MODCONFIG.CONSTRUCTION_MASS_MULTIPLIER.TOOLTIP"
+msgid ""
+"Multiplies the building material mass when converting into a spawned natural tile/backwall.\n"
+"This allows compensating for the 50% mass loss on digging the natural tile.\n"
+"Example with x1.5: 100kg construction mass -> 150kg natural tile/backwall -> digging result 75kg"
+msgstr ""
+"将建造材料转化为自然砖或自然背景墙时，生成质量会乘以此倍率。\n"
+"这可以补偿挖掘自然砖时损失的 50% 质量。\n"
+"例如设为 x1.5：100kg 建造材料 -> 150kg 自然砖或自然背景墙 -> 挖掘后获得 75kg 材料"
+
+#. NaturalConstruction.STRINGS.UI.NC_MODCONFIG.CONSTRUCTIONTIME_MASS_SCALING.TITLE
+msgctxt "NaturalConstruction.STRINGS.UI.NC_MODCONFIG.CONSTRUCTIONTIME_MASS_SCALING.TITLE"
+msgid "Construction time mass scaling"
+msgstr "质量影响建造时间"
+
+#. NaturalConstruction.STRINGS.UI.NC_MODCONFIG.CONSTRUCTIONTIME_MASS_SCALING.TOOLTIP
+msgctxt "NaturalConstruction.STRINGS.UI.NC_MODCONFIG.CONSTRUCTIONTIME_MASS_SCALING.TOOLTIP"
+msgid ""
+"When active, lets the construction time scale with the mass picked for the individual natural building.\n"
+"Otherwise defaults to 30 s."
+msgstr ""
+"启用后，自然砖和自然背景墙的建造时间会随所选质量而变化。\n"
+"否则默认为 30 秒。"
+
+#. NaturalConstruction.STRINGS.UI.NC_MODCONFIG.DEFAULT_MASS_BACKWALL.TITLE
+msgctxt "NaturalConstruction.STRINGS.UI.NC_MODCONFIG.DEFAULT_MASS_BACKWALL.TITLE"
+msgid "Natural Backwall default mass"
+msgstr "自然背景墙默认质量"
+
+#. NaturalConstruction.STRINGS.UI.NC_MODCONFIG.DEFAULT_MASS_BACKWALL.TOOLTIP
+msgctxt "NaturalConstruction.STRINGS.UI.NC_MODCONFIG.DEFAULT_MASS_BACKWALL.TOOLTIP"
+msgid ""
+"Configure the default value for natural backwall mass.\n"
+"This value can be changed on the building plan."
+msgstr ""
+"设置自然背景墙的默认质量。\n"
+"开始建造后仍可修改此数值。"
+
+#. NaturalConstruction.STRINGS.UI.NC_MODCONFIG.DEFAULT_MASS_TILE.TITLE
+msgctxt "NaturalConstruction.STRINGS.UI.NC_MODCONFIG.DEFAULT_MASS_TILE.TITLE"
+msgid "Natural Tile default mass"
+msgstr "自然砖默认质量"
+
+#. NaturalConstruction.STRINGS.UI.NC_MODCONFIG.DEFAULT_MASS_TILE.TOOLTIP
+msgctxt "NaturalConstruction.STRINGS.UI.NC_MODCONFIG.DEFAULT_MASS_TILE.TOOLTIP"
+msgid ""
+"Configure the default value for natural tile mass.\n"
+"This value can be changed on the building plan."
+msgstr ""
+"设置自然砖的默认质量。\n"
+"开始建造后仍可修改此数值。"


### PR DESCRIPTION
## Summary

- add a Simplified Chinese (`zh_CN`) translation for Natural Construction
- translate all 14 current localization entries
- preserve formatting, link tags, and placeholders

## Notes

The translation uses terminology commonly used by the Simplified Chinese Oxygen Not Included community, including “自然砖” and “自然背景墙”.