### PR TITLE
Add CI validation for translation files

### DIFF
--- a/.github/workflows/Validate_Translations.yml
+++ b/.github/workflows/Validate_Translations.yml
@@ -1,0 +1,36 @@
+name: Validate translations
+
+on:
+  pull_request:
+    paths:
+      - "**/ModAssets/translations/*.po"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gettext
+        run: sudo apt-get update && sudo apt-get install --yes gettext
+
+      - name: Validate changed PO files
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git diff --name-only --diff-filter=ACM \
+            "$BASE_SHA" "$HEAD_SHA" -- '*.po' |
+          while IFS= read -r file; do
+            echo "Validating $file"
+            msgfmt --check --check-format \
+              --output-file=/dev/null "$file"
+          done


### PR DESCRIPTION
## Summary

- add a lightweight GitHub Actions workflow for `.po` translation files
- run only when translation files are changed in a pull request
- validate only added or modified PO files with `msgfmt --check --check-format`
- use read-only repository permissions

## Motivation

Translation-only pull requests do not need to rely solely on a full Windows build to catch malformed gettext files. This check provides fast feedback without requiring Oxygen Not Included game assemblies.

## Validation

- checked the workflow with `actionlint`
- verified the changed-file selection against a translation branch