### PR TITLE
Validate translations before PR builds

### DIFF
--- a/.github/workflows/Automatic_BuildOnPR.yml
+++ b/.github/workflows/Automatic_BuildOnPR.yml
@@ -9,7 +9,43 @@ permissions:
   actions: write # Grant write permission to delete old workflow runs
 
 jobs:
+  validate-translations:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Validate changed PO files
+      shell: bash
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        mapfile -d '' files < <(
+          git diff --name-only --diff-filter=ACM -z \
+            "$BASE_SHA" "$HEAD_SHA" -- '*.po'
+        )
+
+        if (( ${#files[@]} == 0 )); then
+          echo "No added or modified PO files to validate."
+          exit 0
+        fi
+
+        sudo apt-get update
+        sudo apt-get install --yes gettext
+
+        for file in "${files[@]}"; do
+          echo "Validating $file"
+          msgfmt --check --check-format \
+            --output-file=/dev/null "$file"
+        done
+
   build:
+    needs: validate-translations
     runs-on: windows-latest
 
     steps:
@@ -32,4 +68,3 @@ jobs:
     #     retain_days: 1
     #     keep_minimum_runs: 3
           
-


### PR DESCRIPTION
## Summary

- integrate PO validation into the existing pull-request build workflow
- check only added or modified `.po` files with `msgfmt --check --check-format`
- skip gettext installation when a pull request contains no translation changes
- require translation validation to pass before starting the full Windows build

## Motivation

The existing build copies translation assets without parsing them, so malformed PO files can pass compilation. Integrating this check into the existing workflow keeps CI consolidated and avoids a full build when translation validation already fails.

## Validation

- checked the updated workflow with `actionlint`
- parsed the workflow as YAML
- verified the changed-file selection against a translation branch