### PR TITLE
Fix: Force enable IME after KInputTextField.LateUpdate to allow Chine…

### DIFF
--- a/BlueprintsV2/BlueprintsV2/Patches/KInputTextFieldPatch.cs
+++ b/BlueprintsV2/BlueprintsV2/Patches/KInputTextFieldPatch.cs
@@ -1,0 +1,16 @@
+﻿using HarmonyLib;
+using UnityEngine;
+
+namespace BlueprintsV2.Patches
+{
+    [HarmonyPatch(typeof(KInputTextField))]
+    [HarmonyPatch("LateUpdate")]
+    public static class KInputTextFieldPatch
+    {
+        public static void Postfix()
+        {
+            // 在 LateUpdate 执行完毕后强制全局 IME 开启
+            UnityEngine.Input.imeCompositionMode = UnityEngine.IMECompositionMode.On;
+        }
+    }
+}


### PR DESCRIPTION
…se input when creating new blueprints

- Add KInputTextFieldPatch via Harmony to set Input.imeCompositionMode = On after LateUpdate

Root Cause

- The custom input field KInputTextField (from Klei) inherits from TMP_InputField and overrides the LateUpdate method.
- In LateUpdate, the game resets IME-related input states, overriding any IME settings we apply.
- When creating a new blueprint, SpeedControlScreen.Instance.Pause(false) is called, pausing the game. This affects the timing of LateUpdate execution, causing IME to be unexpectedly disabled. In contrast, the rename dialog does not pause the game, so IME works normally.