### PR TITLE
Fix: Force enable IME after KInputTextField.LateUpdate to allow Chine…

### DIFF
--- a/BlueprintsV2/BlueprintsV2.csproj
+++ b/BlueprintsV2/BlueprintsV2.csproj
@@ -50,5 +50,8 @@
 			<HintPath>..\TwitchLib\ONI_Together_API.dll</HintPath>
 			<!--<HintPath>C:\Users\Admin\source\repos\Oxygen_Not_Included_Multiplayer\ONI_Together_API\bin\Debug\net472\ONI_Together_API.dll</HintPath>-->
 		</Reference>
+		<Reference Include="UnityEngine.InputLegacyModule">
+		  <HintPath>$(GameLibsFolder)\UnityEngine.InputLegacyModule.dll</HintPath>
+		</Reference>
 	</ItemGroup>
 </Project>

--- a/BlueprintsV2/BlueprintsV2/Patches/KInputTextFieldPatch.cs
+++ b/BlueprintsV2/BlueprintsV2/Patches/KInputTextFieldPatch.cs
@@ -1,0 +1,25 @@
+﻿using HarmonyLib;
+using UnityEngine;
+using UtilLibs;  // 引用 DialogUtil
+
+namespace BlueprintsV2.Patches
+{
+    [HarmonyPatch(typeof(KInputTextField))]
+    [HarmonyPatch("LateUpdate")]
+    public static class KInputTextFieldPatch
+    {
+        public static void Postfix()
+        {
+            // 根据对话框激活状态决定 IME 模式
+            if (DialogUtil.IsInputDialogActive)
+            {
+                UnityEngine.Input.imeCompositionMode = UnityEngine.IMECompositionMode.On;
+            }
+            else
+            {
+                // 无对话框时恢复为 Auto（让系统自动处理）
+                UnityEngine.Input.imeCompositionMode = UnityEngine.IMECompositionMode.Auto;
+            }
+        }
+    }
+}

--- a/UtilLibs/DialogUtil.cs
+++ b/UtilLibs/DialogUtil.cs
@@ -10,6 +10,7 @@ namespace UtilLibs
 {
 	public static class DialogUtil
 	{
+		public static bool IsInputDialogActive = false;
 		public static void CreateConfirmDialogFrontend(string title = null, string text = null, string confirm_text = null, System.Action on_confirm = null, string cancel_text = null, System.Action on_cancel = null, string configurable_text = null, System.Action on_configurable_clicked = null, Sprite image_sprite = null, bool useScreenSpaceOverlay = false, GameObject parent = null)
 		=> CreateConfirmDialog(title, text, confirm_text, on_confirm, cancel_text, on_cancel, configurable_text, on_configurable_clicked, image_sprite, true, useScreenSpaceOverlay, parent);
 		public static ConfirmDialogScreen CreateConfirmDialog(string title = null, string text = null, string confirm_text = null, System.Action on_confirm = null, string cancel_text = null, System.Action on_cancel = null, string configurable_text = null, System.Action on_configurable_clicked = null, Sprite image_sprite = null, bool frontend = false, bool useScreenSpaceOverlay = false, GameObject parent = null)
@@ -120,6 +121,12 @@ namespace UtilLibs
 			{
 				titleText.text = title;
 			}
+			
+			// ===== 新增：IME 开关控制 =====
+			IsInputDialogActive = true;
+			textDialog.onConfirm += (string result) => { IsInputDialogActive = false; };
+			textDialog.onCancel += () => { IsInputDialogActive = false; };
+			// ===== 新增结束 =====
 
 			return textDialog;
 		}


### PR DESCRIPTION
…se input when creating new blueprints

- Add KInputTextFieldPatch via Harmony to set Input.imeCompositionMode = On after LateUpdate
- Add static flag DialogUtil.IsInputDialogActive to control IME only during text input dialogs
- Set flag true when FileNameDialog is created, false on confirm/cancel
- Prevents global IME interference with game shortcuts

**Root Cause**
- The custom input field KInputTextField (from Klei) inherits from TMP_InputField and overrides the LateUpdate method.
- In LateUpdate, the game resets IME-related input states, overriding any IME settings we apply.
- When creating a new blueprint, SpeedControlScreen.Instance.Pause(false) is called, pausing the game. This affects the timing of LateUpdate execution, causing IME to be unexpectedly disabled. In contrast, the rename dialog does not pause the game, so IME works normally.