### PR TITLE
Fix IME input not working in new blueprint naming dialog

### DIFF
--- a/BlueprintsV2/BlueprintsV2.csproj
+++ b/BlueprintsV2/BlueprintsV2.csproj
@@ -50,5 +50,9 @@
 			<HintPath>..\TwitchLib\ONI_Together_API.dll</HintPath>
 			<!--<HintPath>C:\Users\Admin\source\repos\Oxygen_Not_Included_Multiplayer\ONI_Together_API\bin\Debug\net472\ONI_Together_API.dll</HintPath>-->
 		</Reference>
+		<Reference Include="UnityEngine.InputLegacyModule">
+			<HintPath>$(GameLibsFolder)\UnityEngine.InputLegacyModule.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
 	</ItemGroup>
 </Project>

--- a/BlueprintsV2/BlueprintsV2/Tools/CreateBlueprintTool.cs
+++ b/BlueprintsV2/BlueprintsV2/Tools/CreateBlueprintTool.cs
@@ -154,20 +154,26 @@ namespace BlueprintsV2.Tools
 				ModAssets.BlueprintFileHandling.HandleBlueprintLoading(blueprint.FilePath);
 
 				SpeedControlScreen.Instance.Unpause(false);
-
+				
 				CameraController.Instance.DisableUserCameraControl = false;
 				PopFXManager.Instance.SpawnFX(ModAssets.BLUEPRINTS_CREATE_ICON_SPRITE, STRINGS.UI.TOOLS.CREATE_TOOL.CREATED, null, PlayerController.GetCursorPos(KInputManager.GetMousePos()), Config.Instance.FXTime);
 				UnlockCam();
+				// Restore IME (optional)
+				Input.imeCompositionMode = IMECompositionMode.Auto;
 			}
 			void OnCancelDelegate()
 			{
 				SpeedControlScreen.Instance.Unpause(false);
-
+				
 				PopFXManager.Instance.SpawnFX(ModAssets.BLUEPRINTS_CREATE_ICON_SPRITE, STRINGS.UI.TOOLS.CREATE_TOOL.CANCELLED, null, PlayerController.GetCursorPos(KInputManager.GetMousePos()), Config.Instance.FXTime);
 				UnlockCam();
+				// Restore IME (optional)
+				Input.imeCompositionMode = IMECompositionMode.Auto;
 			}
-					
+
 			SpeedControlScreen.Instance.Pause(false);
+			// Enable IME
+			Input.imeCompositionMode = IMECompositionMode.On;
 			FileNameDialog blueprintNameDialog = DialogUtil.CreateTextInputDialog(STRINGS.UI.DIALOGUE.NAMEBLUEPRINT_TITLE, blueprint.Folder, null, true, OnConfirmDelegate, OnCancelDelegate);
 
 			blueprintNameDialog.Activate();


### PR DESCRIPTION
## Problem

IME input (Chinese/Japanese/Korean) does not work in the new blueprint naming dialog. Copy-paste works, rename works.

## What I tried and failed

- Adjusting pause timing
- Adding ModAssets.ParentScreen
- Restoring EventSystem
- Cleaning tool states (hasFocus, RemoveCurrentAreaText, areaVisualizer)
- Temporarily switching to SelectTool

None of these fixed the issue.

## What works

Adding one line before creating the dialog:

`Input.imeCompositionMode = IMECompositionMode.On;`

## Why this fix

I was unable to identify the exact root cause. The interference appears to be caused by a combination of internal states set during `DragTool.OnLeftClickDown` (EventSystem disabled, hasFocus, areaVisualizerText, areaVisualizer). Individual cleanup attempts did not restore IME functionality.

Rather than spending more time investigating the exact cause, this PR provides a simple