### PR TITLE
add: apply blueprint settings to completed buildings via task system

### DIFF
--- a/BlueprintsV2/BlueprintsV2/ModAPI/BlueprintTemplateCache.cs
+++ b/BlueprintsV2/BlueprintsV2/ModAPI/BlueprintTemplateCache.cs
@@ -1,0 +1,365 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+using UtilLibs;
+
+namespace BlueprintsV2.ModAPI
+{
+    public static class BlueprintTemplateCache
+    {
+        private static readonly Dictionary<string, GameObject> _cache = new Dictionary<string, GameObject>();
+
+        public static GameObject GetOrCreateTemplate(BuildingDef def)
+        {
+            if (def == null) throw new ArgumentNullException(nameof(def));
+
+            string key = def.PrefabID;
+            if (_cache.TryGetValue(key, out GameObject template) && template != null)
+            {
+                ResetTemplateData(template);
+                return template;
+            }
+
+            var prefab = def.BuildingComplete;
+            if (prefab == null)
+            {
+                SgtLogger.error($"BuildingComplete prefab is null for {def.PrefabID}");
+                return null;
+            }
+
+            Vector3 hiddenPos = new Vector3(-10000f, -10000f, 0f);
+            template = GameUtil.KInstantiate(prefab, hiddenPos, Grid.SceneLayer.Background, null, 0);
+            template.SetActive(false);
+            template.GetComponent<KPrefabID>().AddTag(GameTags.TemplateBuilding);
+
+            if (template.GetComponent<CopyBuildingSettings>() == null)
+                template.AddComponent<CopyBuildingSettings>();
+
+            _cache[key] = template;
+            return template;
+        }
+
+        private static void ResetTemplateData(GameObject go)
+        {
+            // 1. Storage
+            var storage = go.GetComponent<Storage>();
+            if (storage != null)
+            {
+                storage.storageFilters?.Clear();
+                storage.SetOnlyFetchMarkedItems(false);
+            }
+
+            // 2. TreeFilterable
+            var treeFilter = go.GetComponent<TreeFilterable>();
+            if (treeFilter != null)
+            {
+                treeFilter.AcceptedTags?.Clear();
+            }
+
+            // 3. Filterable
+            var filterable = go.GetComponent<Filterable>();
+            if (filterable != null)
+            {
+                filterable.SelectedTag = Tag.Invalid;
+            }
+
+            // 4. FlatTagFilterable
+            var flatFilter = go.GetComponent<FlatTagFilterable>();
+            if (flatFilter != null)
+            {
+                flatFilter.selectedTags?.Clear();
+                // 它还会更新 TreeFilterable
+                treeFilter = go.GetComponent<TreeFilterable>();
+                treeFilter?.AcceptedTags?.Clear();
+            }
+
+            // 5. AccessControl
+            var accessControl = go.GetComponent<AccessControl>();
+            if (accessControl != null)
+            {
+                accessControl.savedPermissionsById?.Clear();
+                accessControl.defaultPermissionByTag?.Clear();
+            }
+
+            // 6. Valve
+            var valve = go.GetComponent<Valve>();
+            if (valve != null)
+            {
+                valve.ChangeFlow(0f);
+            }
+
+            // 7. LimitValve
+            var limitValve = go.GetComponent<LimitValve>();
+            if (limitValve != null)
+            {
+                limitValve.Limit = 0f;
+            }
+
+            // 8. LogicTimerSensor
+            var timerSensor = go.GetComponent<LogicTimerSensor>();
+            if (timerSensor != null)
+            {
+                timerSensor.onDuration = 10f;
+                timerSensor.offDuration = 10f;
+                timerSensor.timeElapsedInCurrentState = 0f;
+                timerSensor.displayCyclesMode = false;
+            }
+
+            // 9. LogicCritterCountSensor
+            var critterSensor = go.GetComponent<LogicCritterCountSensor>();
+            if (critterSensor != null)
+            {
+                critterSensor.countThreshold = 0;
+                critterSensor.activateOnGreaterThan = true;
+                critterSensor.countCritters = true;
+                critterSensor.countEggs = true;
+            }
+
+            // 10. LogicCounter
+            var counter = go.GetComponent<LogicCounter>();
+            if (counter != null)
+            {
+                counter.maxCount = 10;
+                counter.resetCountAtMax = false;
+                counter.advancedMode = false;
+                counter.currentCount = 0;
+            }
+
+            // 11. LogicTimeOfDaySensor
+            var timeOfDaySensor = go.GetComponent<LogicTimeOfDaySensor>();
+            if (timeOfDaySensor != null)
+            {
+                timeOfDaySensor.startTime = 0f;
+                timeOfDaySensor.duration = 0f;
+            }
+
+            // 12. LogicAlarm
+            var alarm = go.GetComponent<LogicAlarm>();
+            if (alarm != null)
+            {
+                alarm.notificationName = "";
+                alarm.notificationTooltip = "";
+                alarm.notificationType = NotificationType.Neutral;
+                alarm.pauseOnNotify = false;
+                alarm.zoomOnNotify = false;
+                alarm.cooldown = 0f;
+            }
+
+            // 13. LogicClusterLocationSensor
+            var clusterSensor = go.GetComponent<LogicClusterLocationSensor>();
+            if (clusterSensor != null)
+            {
+                clusterSensor.activeInSpace = false;
+                clusterSensor.activeLocations?.Clear();
+            }
+
+            // 14. IUserControlledCapacity
+            var userCapacity = go.GetComponent<IUserControlledCapacity>();
+            if (userCapacity != null)
+            {
+                userCapacity.UserMaxCapacity = 0f;
+            }
+
+            // 15. IActivationRangeTarget
+            var rangeTarget = go.GetComponent<IActivationRangeTarget>();
+            if (rangeTarget != null)
+            {
+                rangeTarget.ActivateValue = 0;
+                rangeTarget.DeactivateValue = 0;
+            }
+
+            // 16. IThresholdSwitch
+            var thresholdSwitch = go.GetComponent<IThresholdSwitch>();
+            if (thresholdSwitch != null)
+            {
+                thresholdSwitch.Threshold = 0f;
+                thresholdSwitch.ActivateAboveThreshold = true;
+            }
+
+            // 17. Switch
+            var sw = go.GetComponent<Switch>();
+            if (sw != null && sw.IsSwitchedOn)
+            {
+                sw.Toggle();
+            }
+
+            // 18. Door
+            var door = go.GetComponent<Door>();
+            if (door != null)
+            {
+                door.QueueStateChange(Door.ControlState.Auto);
+            }
+
+            // 19. BuildingEnabledButton
+            var btn = go.GetComponent<BuildingEnabledButton>();
+            if (btn != null)
+            {
+                btn.IsEnabled = true;
+            }
+
+            // 20. Repairable – 默认允许修复，无需重置
+
+            // 21. EnergyGenerator
+            var gen = go.GetComponent<EnergyGenerator>();
+            if (gen != null && !gen.ignoreBatteryRefillPercent)
+            {
+                gen.batteryRefillPercent = 0.5f;
+            }
+
+            // 22. Automatable
+            var auto = go.GetComponent<Automatable>();
+            if (auto != null)
+            {
+                auto.SetAutomationOnly(true);
+            }
+
+            // 23. FoodStorage
+            var foodStorage = go.GetComponent<FoodStorage>();
+            if (foodStorage != null)
+            {
+                foodStorage.SpicedFoodOnly = false;
+            }
+
+            // 24. SingleEntityReceptacle
+            var receptacle = go.GetComponent<SingleEntityReceptacle>();
+            if (receptacle != null)
+            {
+                receptacle.autoReplaceEntity = false;
+                receptacle.requestedEntityTag = Tag.Invalid;
+                receptacle.requestedEntityAdditionalFilterTag = Tag.Invalid;
+            }
+
+            // 25. StorageTile (SMI)
+            var storageTileSmi = go.GetSMI<StorageTile.Instance>();
+            if (storageTileSmi != null)
+            {
+                storageTileSmi.SetTargetItem(Tag.Invalid);
+                storageTileSmi.UserMaxCapacity = 0f;
+            }
+
+            // 26. DirectionControl
+            var dirControl = go.GetComponent<DirectionControl>();
+            if (dirControl != null)
+            {
+                dirControl.SetAllowedDirection(WorkableReactable.AllowedDirection.Any);
+            }
+
+            // 27. Clinic
+            var clinic = go.GetComponent<Clinic>();
+            if (clinic != null)
+            {
+                (clinic as ISliderControl)?.SetSliderValue(70f, 0);
+            }
+
+            // 28. SpaceHeater
+            var heater = go.GetComponent<SpaceHeater>();
+            if (heater != null && heater.produceHeat)
+            {
+                heater.SetUserSpecifiedPowerConsumptionValue(0f);
+            }
+
+            // 29. AutoDisinfectable
+            var disinfect = go.GetComponent<AutoDisinfectable>();
+            if (disinfect != null)
+            {
+                disinfect.EnableAutoDisinfect();
+            }
+
+            // 30. LogicGateBuffer / LogicGateFilter
+            TryResetGenericLogicGateDelay(go);
+
+            // 31. LogicRibbonWriter / Reader
+            var writer = go.GetComponent<LogicRibbonWriter>();
+            if (writer != null)
+                writer.SetBitSelection(0);
+
+            var reader = go.GetComponent<LogicRibbonReader>();
+            if (reader != null)
+                reader.SetBitSelection(0);
+
+            // 32. PixelPack
+            var pixelPack = go.GetComponent<PixelPack>();
+            if (pixelPack != null)
+            {
+                if (pixelPack.colorSettings != null)
+                {
+                    var defaultPair = new PixelPack.ColorPair
+                    {
+                        activeColor = pixelPack.defaultActive,
+                        standbyColor = pixelPack.defaultStandby
+                    };
+                    for (int i = 0; i < pixelPack.colorSettings.Count; i++)
+                    {
+                        pixelPack.colorSettings[i] = defaultPair;
+                    }
+                }
+                pixelPack.UpdateColors();
+            }
+
+            // 33. HighEnergyParticleSpawner
+            var spawner = go.GetComponent<HighEnergyParticleSpawner>();
+            if (spawner != null)
+            {
+                spawner.Direction = EightDirection.Right;
+                spawner.particleThreshold = 50f;
+            }
+
+            // 34. HighEnergyParticleRedirector
+            var redirector = go.GetComponent<HighEnergyParticleRedirector>();
+            if (redirector != null)
+            {
+                redirector.Direction = EightDirection.Right;
+            }
+
+            // 35. HEPBattery (SMI)
+            var hepBattery = go.GetSMI<HEPBattery.Instance>();
+            if (hepBattery != null)
+            {
+                hepBattery.particleThreshold = 50f;
+            }
+
+            // 36. UserNameable
+            var nameable = go.GetComponent<UserNameable>();
+            if (nameable != null)
+            {
+                nameable.SetName("");
+            }
+
+            // 37. Prioritizable
+            var prioritizable = go.GetComponent<Prioritizable>();
+            if (prioritizable != null)
+            {
+                prioritizable.SetMasterPriority(new PrioritySetting(PriorityScreen.PriorityClass.basic, 5));
+            }
+        }
+
+        private static void TryResetGenericLogicGateDelay(GameObject go)
+        {
+            var buffer = go.GetComponent<LogicGateBuffer>();
+            if (buffer != null)
+            {
+                var prop = typeof(LogicGateBuffer).GetProperty("DelayAmount");
+                prop?.SetValue(buffer, 5f, null);
+            }
+
+            var filter = go.GetComponent<LogicGateFilter>();
+            if (filter != null)
+            {
+                var prop = typeof(LogicGateFilter).GetProperty("DelayAmount");
+                prop?.SetValue(filter, 5f, null);
+            }
+        }
+
+        public static void Clear()
+        {
+            foreach (var kvp in _cache)
+            {
+                if (kvp.Value != null)
+                    UnityEngine.Object.Destroy(kvp.Value);
+            }
+            _cache.Clear();
+            SgtLogger.l("BlueprintTemplateCache cleared.");
+        }
+    }
+}

--- a/BlueprintsV2/BlueprintsV2/Tools/BlueprintSettingsApplier.cs
+++ b/BlueprintsV2/BlueprintsV2/Tools/BlueprintSettingsApplier.cs
@@ -41,53 +41,40 @@ namespace BlueprintsV2.Tools
             if (targetPrefab == null)
                 return false;
 
-            GameObject sourceGO = null;
-            try
+            // 从缓存获取模板（隐藏、非激活）
+            var buildingDef = buildingConfig.BuildingDef;
+            if (buildingDef == null)
+                return false;
+
+            GameObject sourceGO = BlueprintTemplateCache.GetOrCreateTemplate(buildingDef);
+            if (sourceGO == null)
+                return false;
+
+            // 将蓝图数据应用到模板（完全覆盖）
+            ModAPI.API_Methods.ApplyAdditionalBuildingData(sourceGO, buildingConfig, playerId);
+
+            // 执行复制（触发事件）
+            var sourceCopy = sourceGO.GetComponent<CopyBuildingSettings>();
+            bool success = CopyBuildingSettings.ApplyCopy(
+                targetPrefab,
+                sourceGO,
+                sourceGO.GetComponent<KPrefabID>(),
+                sourceCopy
+            );
+
+            // 显示提示
+            if (success && cell != Grid.InvalidCell)
             {
-                // 3. 创建临时源建筑（隐藏，不激活物理）
-                var sourcePrefab = buildingConfig.BuildingDef.BuildingComplete;
-                Vector3 hiddenPos = new Vector3(-10000f, -10000f, 0f);
-                sourceGO = GameUtil.KInstantiate(sourcePrefab, hiddenPos, Grid.SceneLayer.Background, null, 0);
-                sourceGO.SetActive(false);
-                sourceGO.GetComponent<KPrefabID>().AddTag(GameTags.TemplateBuilding);
-
-                // 4. 将蓝图设置应用到临时源建筑
-                ModAPI.API_Methods.ApplyAdditionalBuildingData(sourceGO, buildingConfig, playerId);
-                sourceGO.SetActive(false);
-
-                // 5. 确保源建筑有 CopyBuildingSettings
-                var sourceCopy = sourceGO.GetComponent<CopyBuildingSettings>();
-                if (sourceCopy == null)
-                    sourceCopy = sourceGO.AddComponent<CopyBuildingSettings>();
-
-                // 6. 调用 ApplyCopy 触发复制事件（各组件会监听并生成任务）
-                bool success = CopyBuildingSettings.ApplyCopy(
-                    targetPrefab,
-                    sourceGO,
-                    sourceGO.GetComponent<KPrefabID>(),
-                    sourceCopy
+                PopFXManager.Instance.SpawnFX(
+                    ModAssets.BLUEPRINTS_APPLY_SETTINGS_SPRITE,
+                    "Settings copied, waiting for Duplicant",
+                    null,
+                    offset: Grid.CellToPos(cell),
+                    Config.Instance.FXTime
                 );
-
-                // 7. 显示提示
-                if (success && cell != Grid.InvalidCell)
-                {
-                    PopFXManager.Instance.SpawnFX(
-                        ModAssets.BLUEPRINTS_APPLY_SETTINGS_SPRITE,
-                        "Settings copied, waiting for Duplicant",
-                        null,
-                        offset: Grid.CellToPos(cell),
-                        Config.Instance.FXTime
-                    );
-                }
-
-                return success;
             }
-            finally
-            {
-                // 清理临时对象
-                if (sourceGO != null)
-                    UnityEngine.Object.Destroy(sourceGO);
-            }
+
+            return success;
         }
     }
 }

--- a/BlueprintsV2/BlueprintsV2/Tools/BlueprintSettingsApplier.cs
+++ b/BlueprintsV2/BlueprintsV2/Tools/BlueprintSettingsApplier.cs
@@ -1,0 +1,93 @@
+using System;
+using BlueprintsV2.BlueprintData;
+using BlueprintsV2.ModAPI;
+using UnityEngine;
+
+namespace BlueprintsV2.Tools
+{
+    /// <summary>
+    /// 用于将蓝图设置应用到已完工建筑，并触发生成复制设置任务
+    /// </summary>
+    public static class BlueprintSettingsApplier
+    {
+        /// <summary>
+        /// 将蓝图设置应用到目标建筑（已完工），生成任务等待小人执行
+        /// </summary>
+        /// <param name="targetGO">目标建筑对象</param>
+        /// <param name="buildingConfig">蓝图配置</param>
+        /// <param name="playerId">玩家ID</param>
+        /// <param name="cell">用于提示位置</param>
+        /// <returns>是否成功触发复制</returns>
+        public static bool ApplySettingsToCompletedBuilding(
+            GameObject targetGO,
+            BuildingConfig buildingConfig,
+            ulong playerId,
+            int cell)
+        {
+            if (targetGO == null || buildingConfig == null)
+                return false;
+
+            // 检查是否有设置数据
+            if (!buildingConfig.HasAnyBuildingData)
+                return false;
+
+            // 1. 检查目标建筑是否有 CopyBuildingSettings，没有则添加
+            var targetCopy = targetGO.GetComponent<CopyBuildingSettings>();
+            if (targetCopy == null)
+                targetCopy = targetGO.AddComponent<CopyBuildingSettings>();
+
+            // 2. 获取目标建筑的 KPrefabID
+            var targetPrefab = targetGO.GetComponent<KPrefabID>();
+            if (targetPrefab == null)
+                return false;
+
+            GameObject sourceGO = null;
+            try
+            {
+                // 3. 创建临时源建筑（隐藏，不激活物理）
+                var sourcePrefab = buildingConfig.BuildingDef.BuildingComplete;
+                Vector3 hiddenPos = new Vector3(-10000f, -10000f, 0f);
+                sourceGO = GameUtil.KInstantiate(sourcePrefab, hiddenPos, Grid.SceneLayer.Background, null, 0);
+                sourceGO.SetActive(false);
+                sourceGO.GetComponent<KPrefabID>().AddTag(GameTags.TemplateBuilding);
+
+                // 4. 将蓝图设置应用到临时源建筑
+                ModAPI.API_Methods.ApplyAdditionalBuildingData(sourceGO, buildingConfig, playerId);
+                sourceGO.SetActive(false);
+
+                // 5. 确保源建筑有 CopyBuildingSettings
+                var sourceCopy = sourceGO.GetComponent<CopyBuildingSettings>();
+                if (sourceCopy == null)
+                    sourceCopy = sourceGO.AddComponent<CopyBuildingSettings>();
+
+                // 6. 调用 ApplyCopy 触发复制事件（各组件会监听并生成任务）
+                bool success = CopyBuildingSettings.ApplyCopy(
+                    targetPrefab,
+                    sourceGO,
+                    sourceGO.GetComponent<KPrefabID>(),
+                    sourceCopy
+                );
+
+                // 7. 显示提示
+                if (success && cell != Grid.InvalidCell)
+                {
+                    PopFXManager.Instance.SpawnFX(
+                        ModAssets.BLUEPRINTS_APPLY_SETTINGS_SPRITE,
+                        "Settings copied, waiting for Duplicant",
+                        null,
+                        offset: Grid.CellToPos(cell),
+                        Config.Instance.FXTime
+                    );
+                }
+
+                return success;
+            }
+            finally
+            {
+                // 清理临时对象
+                if (sourceGO != null)
+                    UnityEngine.Object.Destroy(sourceGO);
+            }
+        }
+    }
+}

--- a/BlueprintsV2/BlueprintsV2/Visualizers/BuildingVisual.cs
+++ b/BlueprintsV2/BlueprintsV2/Visualizers/BuildingVisual.cs
@@ -592,12 +592,28 @@ namespace BlueprintsV2.Visualizers
 			//}
 			else if (SameBuildingAlreadyInPlace(cellParam, out var bc, true) || CanApplyConduitSettings(cellParam)) //apply building settings to existing, does not apply to conduits
 			{
+				// 已完工建筑：使用封装的方法复制设置并生成任务
+				var buildingGO = bc.gameObject;
+				var underConstruction = buildingGO.GetComponent<BuildingUnderConstruction>();
+				var complete = buildingGO.GetComponent<BuildingComplete>();
+				if (complete != null && underConstruction == null)
+				{
+					BlueprintSettingsApplier.ApplySettingsToCompletedBuilding(
+						buildingGO,
+						buildingConfig,
+						_playerId,
+						cellParam
+					);
+					return true;
+				}
+
+				// 正在建造的建筑：直接应用设置
 				ApplyBuildingData(bc.gameObject, false);
 				if (buildingConfig.HasAnyBuildingData)
 				{
 					PopFXManager.Instance.SpawnFX(ModAssets.BLUEPRINTS_APPLY_SETTINGS_SPRITE, STRINGS.UI.TOOLS.USE_TOOL.SETTINGS_APPLIED, null, offset: Grid.CellToPos(cellParam), Config.Instance.FXTime);
 				}
-
+				
 				return true;
 			}
 

--- a/BlueprintsV2/BlueprintsV2/Visualizers/BuildingVisual.cs
+++ b/BlueprintsV2/BlueprintsV2/Visualizers/BuildingVisual.cs
@@ -592,10 +592,29 @@ namespace BlueprintsV2.Visualizers
 			//}
 			else if (SameBuildingAlreadyInPlace(cellParam, out var bc, true) || CanApplyConduitSettings(cellParam)) //apply building settings to existing, does not apply to conduits
 			{
-				// 已完工建筑：使用封装的方法复制设置并生成任务
+				// 已完工建筑：使用封装的方法复制设置并生成任务	
+				// Completed Buildings: Use the encapsulation method to replicate settings and generate tasks
 				var buildingGO = bc.gameObject;
 				var underConstruction = buildingGO.GetComponent<BuildingUnderConstruction>();
 				var complete = buildingGO.GetComponent<BuildingComplete>();
+				
+					//1. 网络类建筑直接应用设置（不生成任务）
+					//1. Direct Application Settings for Network-Based Structures (No Tasks Generated)
+				if (buildingGO.GetComponent<IHaveUtilityNetworkMgr>() != null)
+				{
+					// 水管、气体管道、电线、信号线、运输轨道直接应用设置 Direct installation of water pipes, gas lines, electrical wires, signal cables, and transport tracks
+					ApplyBuildingData(buildingGO, false);
+					if (buildingConfig.HasAnyBuildingData)
+					{
+						PopFXManager.Instance.SpawnFX(ModAssets.BLUEPRINTS_APPLY_SETTINGS_SPRITE, 
+							STRINGS.UI.TOOLS.USE_TOOL.SETTINGS_APPLIED, 
+							null, offset: Grid.CellToPos(cellParam), Config.Instance.FXTime);
+					}
+					return true;
+				}
+				
+					//2. 已完工建筑（非网络类）：生成任务
+					//2. Completed Buildings (Non-Network): Generate Task
 				if (complete != null && underConstruction == null)
 				{
 					BlueprintSettingsApplier.ApplySettingsToCompletedBuilding(
@@ -608,6 +627,7 @@ namespace BlueprintsV2.Visualizers
 				}
 
 				// 正在建造的建筑：直接应用设置
+				// Buildings Under Construction: Direct Application Settings
 				ApplyBuildingData(bc.gameObject, false);
 				if (buildingConfig.HasAnyBuildingData)
 				{


### PR DESCRIPTION
add: apply blueprint settings to completed buildings via task system

- Completed buildings now receive blueprint settings through CopyBuildingSettings.ApplyCopy
- This triggers Storage, TreeFilterable, AccessControl components to generate tasks
- Settings are queued for Duplicant execution instead of being applied instantly
- Extract logic to BlueprintSettingsApplier helper class for better maintainability
- Exclude utility network buildings(water pipes, gas lines, electrical wires, signal cables, and transport tracks) from settings task queue.