### PR TITLE
BlueprintsV2: fix blueprint previews vanishing when the camera moves

### DIFF
--- a/BlueprintsV2/BlueprintsV2/Visualizers/BuildingVisual.cs
+++ b/BlueprintsV2/BlueprintsV2/Visualizers/BuildingVisual.cs
@@ -61,8 +61,8 @@ namespace BlueprintsV2.Visualizers
 			///the kanim batch set a controller ends up in is chosen on registration (which happens on activation),
 			///and a controller that is not flagged as always visible at that point lands in a spatially culled batch set of its spawn chunk.
 			///always visible controllers never re-register on chunk change, so it would then disappear as soon as that chunk scrolls off screen.
-			Visualizer.TryGetComponent<KBatchedAnimController>(out var batchedAnimController);
-			if (batchedAnimController != null)
+			bool hasBatchedAnimController = Visualizer.TryGetComponent<KBatchedAnimController>(out var batchedAnimController);
+			if (hasBatchedAnimController)
 			{
 				batchedAnimController.visibilityType = KAnimControllerBase.VisibilityType.Always;
 				batchedAnimController.isMovable = true;
@@ -77,7 +77,7 @@ namespace BlueprintsV2.Visualizers
 			}
 			ModAPI.API_Methods.ApplyAdditionalBuildingData(Visualizer, buildingConfig, _playerId);
 
-			if (batchedAnimController != null)
+			if (hasBatchedAnimController)
 			{
 				//batchedAnimController.TintColour = GetVisualizerColor(cell);
 
@@ -89,8 +89,8 @@ namespace BlueprintsV2.Visualizers
 			{
 				Visualizer.SetLayerRecursively(LayerMask.NameToLayer("Place"));
 			}
-			ApplyColorIfChanged(cell);
 			hasKbac = kbac != null;
+			ApplyColorIfChanged(cell);
 			UpdateRequirementsState();
 		}
 

--- a/BlueprintsV2/BlueprintsV2/Visualizers/BuildingVisual.cs
+++ b/BlueprintsV2/BlueprintsV2/Visualizers/BuildingVisual.cs
@@ -57,6 +57,18 @@ namespace BlueprintsV2.Visualizers
 			Vector3 positionCbc = Grid.CellToPosCBC(cell, buildingConfig.BuildingDef.SceneLayer);
 			Visualizer = GameUtil.KInstantiate(buildingConfig.BuildingDef.BuildingPreview, positionCbc, Grid.SceneLayer.Front, "BlueprintModBuildingVisualizer", LayerMask.NameToLayer("Place"));
 			Visualizer.transform.SetPosition(positionCbc);
+			///has to happen before the visualizer is activated;
+			///the kanim batch set a controller ends up in is chosen on registration (which happens on activation),
+			///and a controller that is not flagged as always visible at that point lands in a spatially culled batch set of its spawn chunk.
+			///always visible controllers never re-register on chunk change, so it would then disappear as soon as that chunk scrolls off screen.
+			Visualizer.TryGetComponent<KBatchedAnimController>(out var batchedAnimController);
+			if (batchedAnimController != null)
+			{
+				batchedAnimController.visibilityType = KAnimControllerBase.VisibilityType.Always;
+				batchedAnimController.isMovable = true;
+				batchedAnimController.Offset = buildingConfig.BuildingDef.GetVisualizerOffset();
+			}
+
 			Visualizer.SetActive(true);
 
 			if (Visualizer.TryGetComponent<Rotatable>(out var rotatable))
@@ -65,11 +77,8 @@ namespace BlueprintsV2.Visualizers
 			}
 			ModAPI.API_Methods.ApplyAdditionalBuildingData(Visualizer, buildingConfig, _playerId);
 
-			if (Visualizer.TryGetComponent<KBatchedAnimController>(out var batchedAnimController))
+			if (batchedAnimController != null)
 			{
-				batchedAnimController.visibilityType = KAnimControllerBase.VisibilityType.Always;
-				batchedAnimController.isMovable = true;
-				batchedAnimController.Offset = buildingConfig.BuildingDef.GetVisualizerOffset();
 				//batchedAnimController.TintColour = GetVisualizerColor(cell);
 
 				batchedAnimController.SetLayer(LayerMask.NameToLayer("Place"));

--- a/BlueprintsV2/BlueprintsV2/Visualizers/UtilityVisual.cs
+++ b/BlueprintsV2/BlueprintsV2/Visualizers/UtilityVisual.cs
@@ -13,7 +13,7 @@ namespace BlueprintsV2.Visualizers
 
 		public UtilityVisual(BuildingConfig buildingConfig, int cell, ulong playerId) : base(buildingConfig, cell, playerId)
 		{
-			if (Visualizer.TryGetComponent<KBatchedAnimController>(out var batchedAnimController))
+			if (hasKbac)
 			{
 				IUtilityNetworkMgr utilityNetworkManager = buildingConfig.BuildingDef.BuildingComplete.GetComponent<IHaveUtilityNetworkMgr>().GetNetworkManager();
 
@@ -21,20 +21,12 @@ namespace BlueprintsV2.Visualizers
 				{
 					string animation = utilityNetworkManager.GetVisualizerString((UtilityConnections)flags) + "_place";
 
-					if (batchedAnimController.HasAnimation(animation))
+					if (kbac.HasAnimation(animation))
 					{
-						batchedAnimController.Play(animation);
+						kbac.Play(animation);
 					}
 				}
-
-				batchedAnimController.visibilityType = KAnimControllerBase.VisibilityType.Always;
-				batchedAnimController.isMovable = true;
-				batchedAnimController.Offset = buildingConfig.BuildingDef.GetVisualizerOffset();
-				//batchedAnimController.TintColour = GetVisualizerColor(cell);
-
-				batchedAnimController.SetLayer(LayerMask.NameToLayer("Place"));
 			}
-			ApplyColorIfChanged(cell);
 		}
 
 		public override void ApplyRotation(Orientation rotation, bool flippedX, bool flippedY)


### PR DESCRIPTION
> **Note:** this code was written with the help of AI. Every line has been manually reviewed by me, and every commit has been verified in game.

## Symptom

When a blueprint is selected, parts of the preview disappear as soon as the camera pans or zooms. Whole groups of buildings blink out at once, in blocks, while the tile parts of the same blueprint stay visible.

## Cause

`BuildingVisual` set `visibilityType = Always` *after* `Visualizer.SetActive(true)`:

```cs
Visualizer.SetActive(true);
...
batchedAnimController.visibilityType = KAnimControllerBase.VisibilityType.Always;
```

Activation already registers the `KBatchedAnimController`, and `KAnimBatchManager.Register` decides right at that moment — via `controller.IsAlwaysVisible()` — whether the batch set goes into `uiBatchSets` (never culled) or `culledBatchSetInfos` (culled per 32x32 chunk by `UpdateActiveArea`). The preview was still on default visibility at that point, so every one of them landed in a spatially culled batch set anchored to its spawn chunk.

Setting `Always` a few lines later cannot reclassify an existing batch set, and it makes things worse: `KBatchedAnimController.UpdateAnim` only runs the "chunk changed -> DeRegister/Register" path when `visibilityType != Always`. So the preview stayed pinned to its spawn chunk for its whole life, and vanished as soon as that chunk left the visible area.

Since `BatchKey` includes the chunk index, a blueprint spread over more than 32 cells occupies several batch sets that leave view at different scroll offsets — hence parts disappearing rather than the whole thing.

Vanilla `BuildTool.OnActivateTool` sets `visibilityType` / `isMovable` / `Offset` before `SetActive(true)`; this change makes `BuildingVisual` do the same.

## Changes

- `BuildingVisual`: resolve the `KBatchedAnimController` and set `visibilityType`, `isMovable` and `Offset` before activating the visualizer. `SetLayer`, `Play("place")`, rotation and `ApplyAdditionalBuildingData` stay exactly where they were.
- `UtilityVisual`: drop the duplicated setup that ran after the base constructor had already activated the object. It was dead weight (the base sets all of it, plus `SetLayer`, and caches the controller in `kbac`), and it repeated the very ordering that caused the bug. Only the utility specific part remains: picking and playing the connection animation.
- `BuildingVisual`: assign `hasKbac` before the constructor's `ApplyColorIfChanged(cell)` instead of after. `ApplyColorIfChanged` is gated on `hasKbac`, so that call never did anything, and the trailing `ApplyColorIfChanged` removed from `UtilityVisual` above was in fact the only thing tinting utility previews at construction. It was still safe to remove because `RefreshBlueprintVisualizers` force redraws every visual right after they are built, but the guarantee was implicit. This makes the base call live so it holds directly. Also names the `TryGetComponent` result rather than null checking the `out` parameter twice, matching the other call sites in the file.

`TileVisual` and `UtilityVisual` inherit the fix through the base constructor.

## Scope

Visual only. `BlueprintState.UseBlueprint` iterates the complete `FoundationVisuals` / `DependentVisuals` lists and `TryUse` decides everything from `Grid` state and the `BuildingConfig` — nothing in that path reads the anim controller or its batch. An invisible preview was still placed correctly, with the right material, orientation and building settings.

Not affected and untouched: tile previews (`TileVisual`, drawn by `CustomTileRenderer`, which rebuilds every visible chunk each frame) and the dig / element note / text note / planning shape visuals (they do not set `Always`, so they re-register on chunk change on their own).

## Testing

- Reproduced first on the unpatched build with a 64 cell wide blueprint, then retested the same blueprint after the fix — previews now stay drawn at any zoom level and any distance from where the blueprint was selected.
- Rotation and flipping verified on a blueprint of kanim tiles and 1x1 buildings (wire, gas/liquid pipes, conveyor rail, logic wire, vents, ladder, fire pole): connection animations still resolve correctly through `UtilityVisual` after the cleanup.
- Initial tint verified in game after the `hasKbac` ordering change: previews, utility ones included, show their correct placement colour on the frame they appear rather than only after the first cursor move.
- Release build of the solution passes with 0 errors against the `Lib` reference assemblies, the same path CI uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

